### PR TITLE
Allow re-attaching to running containers

### DIFF
--- a/src/dockerContainers.ts
+++ b/src/dockerContainers.ts
@@ -80,6 +80,11 @@ export class DockerContainers extends DockerTreeBase<DockerContainer> implements
         AppInsightsClient.sendEvent("startContainer");
     }
 
+    public attachContainer(containerName: string): void {
+        Executor.runInTerminal(`docker attach ${containerName}`);
+        AppInsightsClient.sendEvent("attachContainer");
+    }
+
     public stopContainer(containerName: string): void {
         Executor.runInTerminal(`docker stop ${containerName}`);
         AppInsightsClient.sendEvent("stopContainer");

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,6 +29,10 @@ export function activate(context: vscode.ExtensionContext) {
         dockerContainers.startContainer(container.name);
     }));
 
+    context.subscriptions.push(vscode.commands.registerCommand("docker-explorer.attachContainer", (container) => {
+        dockerContainers.attachContainer(container.name);
+    }));
+
     context.subscriptions.push(vscode.commands.registerCommand("docker-explorer.stopContainer", (container) => {
         dockerContainers.stopContainer(container.name);
     }));


### PR DESCRIPTION
The terminal can close for a number of reasons (crash, reloading window after installing extensions... computer crash).

In the situations where the container is still running, lets provide a way to attach to the container again.